### PR TITLE
fix range error in artifacts notebook

### DIFF
--- a/backend/analysis/artifacts.ipynb
+++ b/backend/analysis/artifacts.ipynb
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "671be7242d5491dc",
    "metadata": {
     "ExecuteTime": {
@@ -373,7 +373,7 @@
     "\n",
     "    for app, honeys in results.items():\n",
     "        include_app = False\n",
-    "        for idx in range(min_bucket_id, len(_buckets.keys()) - 1):\n",
+    "        for idx in range(min_bucket_id, len(_buckets.keys())):\n",
     "            bucket_key_to_check = list(_buckets.keys())[idx]\n",
     "            for honey, metrics in honeys.items():\n",
     "                if bucket_key_to_check in metrics.keys() and metrics[bucket_key_to_check] > 0:\n",


### PR DESCRIPTION
The range function from Python is exclusive in the stop parameter, so the last bucket_key was not evaluated
